### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,16 +31,18 @@
     "script-template": "~1.0.3"
   },
   "devDependencies": {
-    "grunt"                 : "~0.4.0",
-    "grunt-contrib-clean"   : "~0.5.0",
-    "grunt-jasmine-node"    : "0.2.1",
-    "jasmine-node"          : "1.14.2"
+    "grunt": "~0.4.0",
+    "grunt-contrib-clean": "~0.5.0",
+    "grunt-jasmine-node": "0.2.1",
+    "jasmine-node": "1.14.2"
   },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
-    "gruntplugin", "template", "generate"
+    "gruntplugin",
+    "template",
+    "generate"
   ],
   "files": [
     "tasks",


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
